### PR TITLE
Fixed error: Could not find a JavaScript runtime

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant::Config.run do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
   config.vm.forward_port 8124, 8124
   config.vm.provision :shell,
-    :inline => "sudo apt-get update && sudo apt-get -y install build-essential git ruby1.9.3 && sudo gem install github-pages --no-ri --no-rdoc"
+    :inline => "sudo apt-get update && sudo apt-get -y install build-essential git ruby1.9.3 && sudo gem install github-pages therubyracer --no-ri --no-rdoc"
 
   config.ssh.forward_agent = true
 end


### PR DESCRIPTION
When running jekyll command in vm, it errors out with `Could not find a JavaScript runtime`

The solution is either to install `therubyracer` gem or nodejs. I've elected to use `therubyracer` gem.

http://jekyllrb.com/docs/troubleshooting/#could-not-find-a-javascript-runtime-execjsruntimeunavailable
